### PR TITLE
docs: refresh README for December 2025 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,18 @@ audnex:
   regions: ["us"]
 ```
 
+**Naming rules** — `config/naming.json`
+
+Naming rules control title/subtitle normalization and filtering used by the naming pipeline (e.g., phrases to remove, author mappings). See `config/naming.json` for the full example.
+
+- `format_indicators`: phrases to remove from titles/subtitles (replaces old `remove_phrases`)
+- `author_map`: explicit foreign name → romanized name mappings
+- `genre_tags`: genre suffixes to strip from titles/subtitles
+- `series_suffixes`: regex patterns to trim from series names
+- `subtitle_patterns`: remove/keep subtitle patterns and related options
+- `subtitle_redundancy_rules`: rules to drop redundant subtitles
+- `preserve_exact`: exact titles that bypass all normalization
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
Updates the project README to reflect recent architecture work and to prevent user-facing footguns.

## Key changes
- Fix install instructions (`mkdir -p config` before copying templates)
- Clarify XDG defaults vs YAML overrides for `state_file`/`log_file`
- Correct `mamfast state` docs to use `asin-or-id` (matches CLI)
- Fix Markdown rendering (remove escaped fences/backticks)
- Replace invalid “pre-commit YAML” snippet with a valid excerpt
- Add CodeRabbit badge and improve navigation/structure

## Testing
- `pytest`
- `pre-commit run --files README.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major README overhaul: styled badges, centered intro, refined nav, expanded feature table, Mermaid pipeline diagram, detailed pipeline stage commands, installation/config updates, env/config/naming rules, and updated license/footer.
  * Expanded Audiobookshelf docs: import/cleanup/restore, trumping rules, and usage examples; added dry-run preview and step-by-step commands.

* **New Features**
  * Noted new pipeline commands, naming rule options, and improved torrent/upload presets described for end users.

* **Chores**
  * Architecture/tooling notes: CLI split, naming refactor, state hardening, and production-grade reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->