### PR TITLE
fix: protect multi-file books from rename data loss

### DIFF
--- a/src/mamfast/commands/abs.py
+++ b/src/mamfast/commands/abs.py
@@ -594,7 +594,7 @@ def cmd_abs_import(args: argparse.Namespace) -> int:
                     )
 
                     # In dry-run, compute what files would be renamed to
-                    # Multi-file books skip renaming to prevent data loss
+                    # Multi-file books preserve track numbers (e.g., " - 01")
                     rename_map: dict[str, str] = {}
                     audio_exts = {".m4b", ".m4a", ".mp3", ".ogg", ".flac", ".opus"}
                     audio_count = sum(
@@ -602,18 +602,33 @@ def cmd_abs_import(args: argparse.Namespace) -> int:
                         for f in source_folder.iterdir()
                         if f.is_file() and f.suffix.lower() in audio_exts
                     )
-                    skip_rename = audio_count > 1  # Multi-file protection
+                    is_multi_file = audio_count > 1
 
-                    if args.dry_run and r.parsed and not skip_rename:
+                    if args.dry_run and r.parsed:
                         try:
                             parsed = r.parsed
+                            base_clean = build_clean_file_name(parsed, extension="")
                             for f in source_folder.iterdir():
                                 if not f.is_file() or should_ignore(f.name, ignore_patterns):
                                     continue
                                 ext = f.suffix.lower()
                                 if f.name.lower().endswith(".metadata.json"):
                                     ext = ".metadata.json"
-                                clean_name = build_clean_file_name(parsed, extension=ext)
+
+                                # For multi-file audio, extract and preserve track suffix
+                                track_suffix = ""
+                                if is_multi_file and ext in audio_exts:
+                                    import re as re_cli
+
+                                    track_match = re_cli.search(r"[\s_-]+(\d{1,3})$", f.stem)
+                                    if track_match:
+                                        track_num = track_match.group(1)
+                                        track_suffix = f" - {int(track_num):02d}"
+                                    else:
+                                        # No track number - skip rename preview
+                                        continue
+
+                                clean_name = f"{base_clean}{track_suffix}{ext}"
                                 if f.name != clean_name:
                                     rename_map[f.name] = clean_name
                         except (ValueError, KeyError):
@@ -622,10 +637,6 @@ def cmd_abs_import(args: argparse.Namespace) -> int:
                     # Show files
                     if files:
                         console.print("  [dim]Files:[/dim]")
-                        if skip_rename:
-                            console.print(
-                                "    [dim italic](multi-file: preserving names)[/dim italic]"
-                            )
                         for filename in files:
                             new_name = rename_map.get(filename)
                             if new_name and new_name != filename:


### PR DESCRIPTION
## Summary
Fixes a critical data loss bug where multi-file audiobooks would have all files renamed to the same filename, causing files to overwrite each other.

## The Problem
When importing multi-file audiobooks (like "Primal Imperative" with 42 m4b files), **all files were being renamed to the same filename**:

```
Primal Imperative ... - 01.m4b → Primal Imperative vol_01 ... .m4b
Primal Imperative ... - 02.m4b → Primal Imperative vol_01 ... .m4b  ← SAME!
Primal Imperative ... - 03.m4b → Primal Imperative vol_01 ... .m4b  ← SAME!
... etc
```

This would cause **data loss** because all files would overwrite each other.

## Root Cause
The multi-file protection check only triggered when there was **no ASIN**:
```python
if len(audio_files) > 1 and not parsed.asin:  # ← BUG: ASIN books not protected
```

But the actual issue is that renaming multiple files to the same base name causes data loss **regardless of ASIN status**.

## The Fix
- Remove the `and not parsed.asin` condition - multi-file books are always protected
- Update CLI preview to show `(multi-file: preserving names)` message
- Update test to verify multi-file books with ASIN are also protected

## Before/After
**Before:**
```
Files:
  Primal Imperative ... - 01.m4b → Primal Imperative vol_01 ... .m4b
  Primal Imperative ... - 02.m4b → Primal Imperative vol_01 ... .m4b  (DATA LOSS!)
```

**After:**
```
Files:
  (multi-file: preserving names)
  Primal Imperative ... - 01.m4b
  Primal Imperative ... - 02.m4b
```

## Testing
✅ All 107 importer tests passing  
✅ All pre-commit hooks passing (ruff, mypy, pytest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-file audiobook renames now preserve track-number suffixes (e.g., " - 01"); files without a detectable track number are skipped to avoid incorrect renames. Added collision checks to avoid overwriting existing files and improved warnings/logs.

* **Tests**
  * Updated and added tests to verify track-number preservation, skipped renames when no track number is found, and dry-run previews that reflect planned track-preserving renames.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->