### PR TITLE
Adds preferred-region ASIN normalization

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -121,6 +121,20 @@ audnex:
     - us
     # - uk  # Uncomment to add UK as fallback
 
+  # Preferred ASIN region for folder/file naming
+  # When an audiobook's ASIN is found in a different region (e.g., "es" for Spain),
+  # mamfast will use Audiobookshelf's Audible search to find the ASIN for the
+  # preferred region. This ensures consistent ASINs across your library.
+  #
+  # Example: A book downloaded from Audible Spain has ASIN B0FDCW8SS7 (Spain).
+  # With preferred_asin_region: us, mamfast searches ABS and finds the US ASIN
+  # B0FDCLSZ7G, which is then used in folder/file names.
+  #
+  # Set to null to disable ASIN normalization (use whatever ASIN is found).
+  # Requires audiobookshelf.enabled: true for the ABS search to work.
+  # Valid: us, uk, au, ca, de, es, fr, in, it, jp, or null
+  preferred_asin_region: us
+
 # ─────────────────────────────────────────────────────────────────────────────
 # MediaInfo (for extracting audio file metadata)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/mamfast/commands/abs.py
+++ b/src/mamfast/commands/abs.py
@@ -458,6 +458,7 @@ def cmd_abs_import(args: argparse.Namespace) -> int:
                 cleanup_prefs=None,  # Cleanup runs separately in Step 5
                 source_paths={f: f for f in staging_folders},  # 1:1 mapping in staging
                 seed_root=settings.paths.seed_root,
+                preferred_asin_region=settings.audnex.preferred_asin_region,
                 progress_callback=progress_callback,
                 dry_run=args.dry_run,
             )

--- a/src/mamfast/libation.py
+++ b/src/mamfast/libation.py
@@ -387,7 +387,9 @@ def run_liberate_with_progress(
     # Passthrough mode: Let Libation draw its own progress
     # -------------------------------------------
     if passthrough_mode:
-        console.print(f"  → Downloading {pending_count} pending book(s)... (Libation progress)")
+        console.print(
+            f"  → Downloading {pending_count} pending audiobook(s)... (Libation progress)"
+        )
         try:
             # Run with inherited stdio so Libation's progress bar shows
             # 1 hour timeout to prevent indefinite hangs
@@ -420,7 +422,7 @@ def run_liberate_with_progress(
 
     try:
         with console.status(
-            f"  → Downloading {pending_count} pending book(s)...",
+            f"  → Downloading {pending_count} pending audiobook(s)...",
             spinner="dots",
         ):
             # 1 hour timeout to prevent indefinite hangs

--- a/tests/test_abs_importer.py
+++ b/tests/test_abs_importer.py
@@ -214,12 +214,13 @@ class TestEnrichFromAudnex:
             },
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0TEST1234")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0TEST1234")
 
         assert result.series == "Epic Adventure"
         assert result.series_position == "5"  # Must be string
         assert isinstance(result.series_position, str)
+        assert region == "us"
 
     def test_series_position_float_coerced_to_string(self) -> None:
         """Handle float position like 1.5 (sub-books)."""
@@ -246,12 +247,13 @@ class TestEnrichFromAudnex:
             },
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0TEST1234")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0TEST1234")
 
         assert result.series == "Epic Adventure"
         assert result.series_position == "1.5"
         assert isinstance(result.series_position, str)
+        assert region == "us"
 
     def test_series_position_none_handled(self) -> None:
         """Handle None position gracefully."""
@@ -278,11 +280,12 @@ class TestEnrichFromAudnex:
             },
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0TEST1234")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0TEST1234")
 
         assert result.series == "Epic Adventure"
         assert result.series_position is None  # Should remain None
+        assert region == "us"
 
     def test_subtitle_series_position_coerced(self) -> None:
         """Subtitle fallback also coerces position to string."""
@@ -308,12 +311,13 @@ class TestEnrichFromAudnex:
             "subtitle": "Epic Adventure, Book 3",
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0TEST1234")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0TEST1234")
 
         assert result.series == "Epic Adventure"
         assert result.series_position == "3"
         assert isinstance(result.series_position, str)
+        assert region == "us"
 
     def test_series_extracted_from_title_pattern(self) -> None:
         """Extract series from title when no seriesPrimary or subtitle available.
@@ -344,13 +348,14 @@ class TestEnrichFromAudnex:
             # No seriesPrimary, no parseable subtitle
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0FZLQ9LQD")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0FZLQ9LQD")
 
         assert result.author == "Brandon Varnell"
         assert result.series == "A Most Unlikely Hero"
         assert result.series_position == "8"
         assert result.is_standalone is False
+        assert region == "us"
 
     def test_series_extracted_from_title_vol_dot_pattern(self) -> None:
         """Extract series from title with 'Vol.' notation."""
@@ -375,11 +380,12 @@ class TestEnrichFromAudnex:
             "authors": [{"name": "Author Name"}],
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B012345678")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B012345678")
 
         assert result.series == "Epic Adventure"
         assert result.series_position == "5"
+        assert region == "us"
 
     def test_series_not_extracted_when_series_primary_exists(self) -> None:
         """Don't extract from title if seriesPrimary already provided series."""
@@ -408,12 +414,13 @@ class TestEnrichFromAudnex:
             },
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B012345678")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B012345678")
 
         # Should use seriesPrimary, NOT extract from title
         assert result.series == "Actual Series Name"
         assert result.series_position == "3"
+        assert region == "us"
 
     def test_audnex_series_overrides_incorrect_parsed_series(self) -> None:
         """Audnex series should override incorrectly parsed series from folder name.
@@ -447,13 +454,14 @@ class TestEnrichFromAudnex:
             },
         }
 
-        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=mock_audnex_data):
-            result = enrich_from_audnex(parsed, "B0BN2GGTCK")
+        with patch("mamfast.abs.importer.fetch_audnex_book", return_value=(mock_audnex_data, "us")):
+            result, region = enrich_from_audnex(parsed, "B0BN2GGTCK")
 
         # Audnex should override the incorrect parsed series
         assert result.series == "The Rising of the Shield Hero"  # "The" inherited
         assert result.series_position == "4"
         assert result.is_standalone is False
+        assert region == "us"
 
 
 # =============================================================================

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -153,7 +153,7 @@ class TestAudnexSchema:
         """Test invalid region codes are rejected."""
         with pytest.raises(ValidationError) as exc_info:
             AudnexSchema(regions=["us", "invalid"])
-        assert "Invalid regions" in str(exc_info.value)
+        assert "Invalid region 'invalid'" in str(exc_info.value)
 
     def test_empty_regions_rejected(self) -> None:
         """Test empty regions list is rejected."""

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -54,11 +54,12 @@ class TestFetchAudnexBook:
             patch("httpx.Client", return_value=mock_client),
             patch("mamfast.metadata.get_settings", return_value=mock_settings),
         ):
-            result = fetch_audnex_book("B09TEST123")
+            result, region = fetch_audnex_book("B09TEST123")
 
         assert result is not None
         assert result["asin"] == "B09TEST123"
         assert result["title"] == "Test Book"
+        assert region == "us"
 
     def test_fetch_not_found(self):
         """Test handling 404 response."""
@@ -79,9 +80,10 @@ class TestFetchAudnexBook:
             patch("httpx.Client", return_value=mock_client),
             patch("mamfast.metadata.get_settings", return_value=mock_settings),
         ):
-            result = fetch_audnex_book("INVALID_ASIN")
+            result, region = fetch_audnex_book("INVALID_ASIN")
 
         assert result is None
+        assert region is None
 
     def test_region_fallback(self):
         """Test fallback to second region when first returns 500."""
@@ -119,11 +121,12 @@ class TestFetchAudnexBook:
             patch("httpx.Client", return_value=mock_client),
             patch("mamfast.metadata.get_settings", return_value=mock_settings),
         ):
-            result = fetch_audnex_book("B09TEST123")
+            result, region = fetch_audnex_book("B09TEST123")
 
         assert result is not None
         assert result["asin"] == "B09TEST123"
         assert call_count == 2  # Both regions tried
+        assert region == "us"  # Found in US region
 
     def test_specific_region_no_fallback(self):
         """Test that specifying region skips fallback."""
@@ -144,9 +147,10 @@ class TestFetchAudnexBook:
             patch("httpx.Client", return_value=mock_client),
             patch("mamfast.metadata.get_settings", return_value=mock_settings),
         ):
-            result = fetch_audnex_book("B09TEST123", region="uk")
+            result, region = fetch_audnex_book("B09TEST123", region="uk")
 
         assert result is None
+        assert region is None
         # Only called once (no fallback to other regions)
         assert mock_client.get.call_count == 1
 
@@ -1193,9 +1197,10 @@ class TestFetchAudnexEdgeCases:
             mock_client.get.side_effect = httpx.TimeoutException("Timeout")
             mock_client_class.return_value = mock_client
 
-            result = fetch_audnex_book("B09TEST123")
+            result, region = fetch_audnex_book("B09TEST123")
 
         assert result is None
+        assert region is None
 
     def test_http_error(self):
         """Test handling HTTP status error."""
@@ -1222,9 +1227,10 @@ class TestFetchAudnexEdgeCases:
             mock_client.get.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = fetch_audnex_book("B09TEST123")
+            result, region = fetch_audnex_book("B09TEST123")
 
         assert result is None
+        assert region is None
 
 
 class TestRunMediainfoEdgeCases:


### PR DESCRIPTION
### Why
- Improves cross-region library consistency by ensuring folder/file naming uses a single, preferred ASIN region, even when downloads originate from different Audible stores.

### What changes
- Adds a configurable preferred ASIN region (default: US) with an option to disable normalization.
- Tracks the region where metadata is found so imports can decide whether normalization is needed.
- Normalizes non-preferred ASINs via an Audiobookshelf Audible search with a higher-confidence threshold, falling back safely on network/API errors.
- Re-checks duplicates after normalization to avoid collisions when the preferred-region ASIN already exists.
- Tightens error handling and validation messaging for region inputs, and expands test coverage around normalization and region tracking.

Fixes MAM ASIN region consistency issue for multi-region libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic ASIN region normalization to map audiobooks to a preferred region when mismatches occur.
  * New configuration option preferred_asin_region to set the target region (default: "us").

* **Bug Fixes**
  * More specific error handling for Audiobookshelf API interactions, improving reliability and logs.

* **Chores**
  * Updated import status label from "pending book(s)" to "pending audiobook(s)".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->